### PR TITLE
Replace pngmath with imgmath

### DIFF
--- a/handout/conf.py
+++ b/handout/conf.py
@@ -26,7 +26,7 @@ sys.path.insert(0, os.path.abspath('../triangle-project'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.pngmath', 'sphinx.ext.mathjax', 'sphinx.ext.viewcode']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.mathjax', 'sphinx.ext.viewcode']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/handout/using-sphinx.rst
+++ b/handout/using-sphinx.rst
@@ -40,7 +40,7 @@ when you use it to create a new project::
    > intersphinx: ... (y/N) [n]:
    > todo: ... (y/N) [n]:
    > coverage: ... (y/N) [n]:
-   > pngmath: ... (y/N) [n]:
+   > imgmath: ... (y/N) [n]:
    > mathjax: ... (y/N) [n]: y
    > ifconfig: ... (y/N) [n]:
    > viewcode: include links to the source code ... (y/N) [n]: y


### PR DESCRIPTION
pngmath has been deprecated, so I removed it from the list of plugins
mathjax is enough to compile latexpdf